### PR TITLE
Remove cache bandaid.

### DIFF
--- a/src/AudioClass.cpp
+++ b/src/AudioClass.cpp
@@ -53,7 +53,7 @@ DaisyHardware AudioClass::init(DaisyDuinoDevice device, DaisyDuinoSampleRate sr)
     // Set Audio Device, num channels, etc.
     // Only difference is Daisy Patch has second AK4556 and 4 channels
     HAL_Init();
-    //SCB_DisableDCache(); // Still needs to wait for linker..
+    SCB_DisableDCache(); // Still needs to wait for linker..
     SCB_EnableDCache();
     SCB_EnableICache();
     _device = device;

--- a/src/AudioClass.cpp
+++ b/src/AudioClass.cpp
@@ -53,7 +53,7 @@ DaisyHardware AudioClass::init(DaisyDuinoDevice device, DaisyDuinoSampleRate sr)
     // Set Audio Device, num channels, etc.
     // Only difference is Daisy Patch has second AK4556 and 4 channels
     HAL_Init();
-    SCB_DisableDCache(); // Still needs to wait for linker..
+    //SCB_DisableDCache(); // Still needs to wait for linker..
     SCB_EnableDCache();
     SCB_EnableICache();
     _device = device;

--- a/src/utility/audio.cpp
+++ b/src/utility/audio.cpp
@@ -243,6 +243,7 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
     SaiHandle::Config::BitDepth bd;
     bd   = audio_handle.sai1_.GetConfig().bit_depth;
     chns = audio_handle.GetChannels();
+	
     if(chns == 0)
         return;
     // Handle Interleaved / Non Interleaved separate
@@ -443,11 +444,11 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
             default: break;
         }
     }
-
+	
 	//temporary bandaid until the cache fix is released via stm32duino
 	for(int i = 0; i < kAudioMaxChannels / 2; i++){
-		//dsy_dma_clear_cache_for_buffer(dsy_audio_rx_buffer[i], kAudioMaxBufferSize);
-		//dsy_dma_clear_cache_for_buffer(dsy_audio_tx_buffer[i], kAudioMaxBufferSize);
+		dsy_dma_invalidate_cache_for_buffer(dsy_audio_rx_buffer[i], kAudioMaxBufferSize);
+		dsy_dma_clear_cache_for_buffer(dsy_audio_tx_buffer[i], kAudioMaxBufferSize);
 	}
 
 }

--- a/src/utility/audio.cpp
+++ b/src/utility/audio.cpp
@@ -444,11 +444,10 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
         }
     }
 
-
 	//temporary bandaid until the cache fix is released via stm32duino
 	for(int i = 0; i < kAudioMaxChannels / 2; i++){
-		dsy_dma_clear_cache_for_buffer(dsy_audio_rx_buffer[i], kAudioMaxBufferSize);
-		dsy_dma_clear_cache_for_buffer(dsy_audio_tx_buffer[i], kAudioMaxBufferSize);
+		//dsy_dma_clear_cache_for_buffer(dsy_audio_rx_buffer[i], kAudioMaxBufferSize);
+		//dsy_dma_clear_cache_for_buffer(dsy_audio_tx_buffer[i], kAudioMaxBufferSize);
 	}
 
 }


### PR DESCRIPTION
Somehow the cache bandaid breaks audio entirely and wasn't ever caught.
Just going to comment it out for now.
The underruns will be fixed with the next stm32duino release.