### PR TITLE
added dedicated TwoWire for onboard codecs.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DaisyDuino
-version=1.5.0
+version=1.5.1
 author=stephenhensley
 maintainer=Electrosmith
 sentence=Arduino library for the Daisy audio platform.

--- a/src/AudioClass.cpp
+++ b/src/AudioClass.cpp
@@ -54,6 +54,7 @@ using namespace daisy;
 dsy_gpio ak4556_reset_pin;
 
 AudioClass DAISY;
+TwoWire daisy_i2c2;
 
 void AudioClass::ConfigureSdram() {
   dsy_gpio_pin *pin_group;
@@ -124,7 +125,7 @@ DaisyHardware AudioClass::init(DaisyDuinoDevice device,
       Wm8731::Config codec_cfg;
       codec_cfg.Defaults();
       Wm8731 codec;
-      codec.Init(codec_cfg);
+      codec.Init(codec_cfg, &daisy_i2c2);
     }
     break;
 
@@ -155,7 +156,7 @@ DaisyHardware AudioClass::init(DaisyDuinoDevice device,
 
   if(_device == DAISY_PATCH_SM){
     Pcm3060 codec;
-    codec.Init();
+    codec.Init(&daisy_i2c2);
   }
 
   // SAI2


### PR DESCRIPTION
For the new hardware (with WM8731 and PCM3060 codecs), the i2c comms were being done with the arduino global `Wire` object. This would cause the pins to get changed from the default, and cause unexpected results when attempting to use the global `Wire` object (since it's pins had been changed).

To resolve this, we added a global `TwoWire` object specifically for the Daisy class to use. That way there will be no interference on the global, and everything else can remain unchanged.

I've personally tested this with seed rev4, seed rev5, and patch_sm using the daisy pod, field, and patch.init() hardware.

I'd like to confirm that everything still works on a clean install on a different machine, but I think this should be good to go.