### PR TITLE
Add ResetToBootloader function

### DIFF
--- a/src/DaisyDuino.cpp
+++ b/src/DaisyDuino.cpp
@@ -1,4 +1,5 @@
 #include "DaisyDuino.h"
+#include "utility/gpio.h"
 
 void DaisyHardware::Init(float control_update_rate, DaisyDuinoDevice device) {
   device_ = device;
@@ -312,4 +313,15 @@ void DaisyHardware::UpdateLeds() {
   }
 
   led_driver_.SwapBuffersAndTransmit();
+}
+
+void DaisyHardware::ResetToBootloader() {
+  dsy_gpio_pin bootpin = {DSY_GPIOG, 3};
+  dsy_gpio pin;
+  pin.mode = DSY_GPIO_MODE_OUTPUT_PP;
+  pin.pin = bootpin;
+  dsy_gpio_init(&pin);
+  dsy_gpio_write(&pin, 1);
+  delay(10);
+  HAL_NVIC_SystemReset();
 }

--- a/src/DaisyDuino.h
+++ b/src/DaisyDuino.h
@@ -122,6 +122,9 @@ public:
   // process boths
   void ProcessAllControls();
 
+  // Reset the hardware in bootloader mode
+  void ResetToBootloader();
+
 private:
   void InitPod(float control_update_rate);
   void InitPatch(float control_update_rate);


### PR DESCRIPTION
### Summary

Adds a method to the DaisyDuino hardware class interface to reset the device into bootloader mode from software.

### Details

This is a simple port of the `System::ResetToBootloader()` function from libDaisy so it can be used from Arduino as well. I could not figure out the correct pin identifier to use the Arduino `pinMode` and `digitalWrite` functions but I don't think that matters for adding the function directly to the hardware class interface, since we can just include the gpio utility header from the cpp file.

[Related Daisy Forum Thread](https://forum.electro-smith.com/t/boot-flash-attached-to-a-pin/804/7)

### Example Usage

```c++
#include "DaisyDuino.h"

DaisyHardware hw;

void MyCallback(float **in, float **out, size_t size) {
  for (size_t i = 0; i < size; i++) {
    out[0][i] = in[0][i];
    out[1][i] = in[1][i];
  }
}

void setup() {
  float sample_rate;
  hw = DAISY.init(DAISY_SEED, AUDIO_SR_48K);
  sample_rate = DAISY.get_samplerate();

  DAISY.begin(MyCallback);

  // blink for 2 seconds
  pinMode(LED_BUILTIN, OUTPUT);
  digitalWrite(LED_BUILTIN, HIGH);
  delay(500);
  digitalWrite(LED_BUILTIN, LOW);
  delay(500);
  digitalWrite(LED_BUILTIN, HIGH);
  delay(500);
  digitalWrite(LED_BUILTIN, LOW);
  delay(500);

  hw.ResetToBootloader();
}

void loop() {}
```