### PR TITLE
PersistentStorage, QSPI external flash, CpuLoadMeter support & ReverbSc extras

### DIFF
--- a/src/CpuLoadMeter.h
+++ b/src/CpuLoadMeter.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "utility/system.h"
+#include <cmath>
+
+namespace daisy
+{
+/** @brief CPU load metering
+ *  @author jelliesen
+ *  @addtogroup utility
+ * 
+ *  To measure the CPU load of your audio processing, create a CpuLoadMeter
+ *  and initialize it with your block size and sample rate.
+ *  Then at the beginning of the audio callback, call `OnBlockStart()`, 
+ *  and at the end of the audio callback, call `OnBlockEnd()`.
+ *  You can then read out the minimum, maximum and average CPU load.
+ */
+class CpuLoadMeter
+{
+  public:
+    CpuLoadMeter(){};
+
+    /** Initializes the CpuLoadMeter for a particular sample rate and block size.
+     *  @param sampleRateInHz           The sample rate in Hz
+     *  @param blockSizeInSamples       The block size in samples
+     *  @param smoothingFilterCutoffHz  The cutoff frequency of the smoothing filter that's used to
+     *                                  create the average CPU load reading.
+     */
+    void Init(float sampleRateInHz,
+              int   blockSizeInSamples,
+              float smoothingFilterCutoffHz = 1.0f)
+    {
+        const auto secPerBlock = float(blockSizeInSamples) / sampleRateInHz;
+        const auto ticksPerS   = float(System::GetTickFreq());
+        ticksPerBlockInv_      = 1.0f / (ticksPerS * secPerBlock);
+
+        // update filter coefficient for smoothing filter (1pole lowpass)
+        const auto blockRateInHz = sampleRateInHz / float(blockSizeInSamples);
+        const auto cutoffNormalized
+            = smoothingFilterCutoffHz * 2.0f * 3.141592653f / blockRateInHz;
+        // according to
+        // https://en.wikipedia.org/wiki/Low-pass_filter#Simple_infinite_impulse_response_filter
+        smoothingConstant_ = cutoffNormalized / (cutoffNormalized + 1.0f);
+
+        Reset();
+    }
+
+    /** Call this at the beginning of your audio callback */
+    void OnBlockStart() { currentBlockStartTicks_ = System::GetTick(); }
+
+    /** Call this at the end of your audio callback */
+    void OnBlockEnd()
+    {
+        const auto end         = System::GetTick();
+        const auto ticksPassed = end - currentBlockStartTicks_;
+        const auto currentBlockLoad
+            = float(ticksPassed) * ticksPerBlockInv_; // usPassed / usPerBlock
+
+        if(firstCycle_)
+        {
+            max_ = min_ = avg_ = currentBlockLoad;
+            firstCycle_        = false;
+        }
+        else
+        {
+            if(currentBlockLoad > max_)
+                max_ = currentBlockLoad;
+            if(currentBlockLoad < min_)
+                min_ = currentBlockLoad;
+
+            avg_ = smoothingConstant_ * currentBlockLoad
+                   + (1.0f - smoothingConstant_) * avg_;
+        }
+    }
+
+    /** Returns the smoothed average CPU load in the range 0..1 */
+    float GetAvgCpuLoad() const { return avg_; }
+    /** Returns the minimun CPU load observed since the last call to Reset(). */
+    float GetMinCpuLoad() const { return min_; }
+    /** Returns the maximum CPU load observed since the last call to Reset(). */
+    float GetMaxCpuLoad() const { return max_; }
+
+    /** Resets the minimun, maximum and average load readings. */
+    void Reset()
+    {
+        firstCycle_ = true;
+        avg_ = max_ = min_ = NAN;
+    }
+
+  private:
+    bool     firstCycle_;
+    float    ticksPerBlockInv_;
+    uint32_t currentBlockStartTicks_;
+    float    min_;
+    float    max_;
+    float    avg_;
+    float    smoothingConstant_;
+
+    CpuLoadMeter(const CpuLoadMeter&) = delete;
+    CpuLoadMeter& operator=(const CpuLoadMeter&) = delete;
+};
+} // namespace daisy

--- a/src/DaisyDuino.h
+++ b/src/DaisyDuino.h
@@ -12,6 +12,7 @@
 #include "daisy_petal.h"
 #include "daisy_pod.h"
 #include "daisy_patch_sm.h"
+#include "PersistentStorage.h"
 
 #include "utility/ctrl.h"
 #include "utility/encoder.h"

--- a/src/PersistentStorage.h
+++ b/src/PersistentStorage.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include "utility/daisy_core.h"
+#include "utility/qspi.h"
+#include "utility/dma.h"
+#include "utility/system.h"
+
+namespace daisy
+{
+/** @brief Non Volatile storage class for persistent settings on an external flash device.
+ *  @author shensley
+ * 
+ *  Storage occupied by the struct will be one word larger than 
+ *  the SettingStruct used. The extra word is used to store the
+ *  state of the data, and whether it's been overwritten or not.
+ * 
+ *  \todo - Make Save() non-blocking
+ *  \todo - Add wear leveling
+ * 
+ **/
+template <typename SettingStruct>
+class PersistentStorage
+{
+  public:
+    /** State of the storage. 
+     *  When created, prior to initialiation, the state will be Unknown
+     *  
+     *  During initialization, the state will be changed to either FACTORY,
+     *  or USER. 
+     * 
+     *  If this is the first time these settings are being written to the
+     *  target address, the defaults will be written to that location,
+     *  and the state will be set to FACTORY.
+     * 
+     *  Once the first user-trigger save has been made, the state will be 
+     *  updated to USER to indicate that the defaults have overwritten.
+     */
+    enum class State
+    {
+        UNKNOWN = 0,
+        FACTORY = 1,
+        USER    = 2,
+    };
+
+    /** Constructor for storage class 
+     *  \param qspi reference to the hardware qspi peripheral.
+     */
+    PersistentStorage(QSPIHandle &qspi)
+    : qspi_(qspi),
+      address_offset_(0),
+      default_settings_(),
+      settings_(),
+      state_(State::UNKNOWN)
+    {
+    }
+
+    /** Initialize Storage class
+     *
+     *  The values in this class will be stored as the default
+     *  for restoration to 'factory' settings.
+     *
+     *  \param defaults should be a setting structure containing the default values.
+     *      this will be updated to contain the stored data.
+     *  \param address_offset offset for location on the QSPI chip (offset to base address of device).
+     *      This defaults to the first address on the chip, and will be masked to the nearest multiple of 256
+     **/
+    void Init(const SettingStruct &defaults, uint32_t address_offset = 0)
+    {
+        default_settings_ = defaults;
+        settings_         = defaults;
+        address_offset_   = address_offset & (uint32_t)(~0xff);
+        auto storage_data
+            = reinterpret_cast<SaveStruct *>(qspi_.GetData(address_offset_));
+
+        // check to see if the state is already in use.
+        State cur_state = storage_data->storage_state;
+        if(cur_state != State::FACTORY && cur_state != State::USER)
+        {
+            // Initialize the Data store State::FACTORY, and the DefaultSettings
+            state_ = State::FACTORY;
+            StoreSettingsIfChanged();
+        }
+        else
+        {
+            state_    = cur_state;
+            settings_ = storage_data->user_data;
+        }
+    }
+
+    /** Returns the state of the Persistent Data */
+    State GetState() const { return state_; }
+
+    /** Returns a reference to the setting struct */
+    SettingStruct &GetSettings() { return settings_; }
+
+    /** Returns a reference to the default setting struct */
+    SettingStruct &GetDefaultSettings() { return default_settings_; }
+
+    /** Performs the save operation, storing the storage */
+    void Save()
+    {
+        state_ = State::USER;
+        StoreSettingsIfChanged();
+    }
+
+    /** Restores the settings stored in the QSPI */
+    void RestoreDefaults()
+    {
+        settings_ = default_settings_;
+        state_    = State::FACTORY;
+        StoreSettingsIfChanged();
+    }
+
+  private:
+    struct SaveStruct
+    {
+        State         storage_state;
+        SettingStruct user_data;
+    };
+
+    void StoreSettingsIfChanged()
+    {
+        SaveStruct s;
+        s.storage_state = state_;
+        s.user_data     = settings_;
+
+        void *data_ptr = qspi_.GetData(address_offset_);
+
+#if !UNIT_TEST
+        // Caching behavior is different when running programs outside internal flash
+        // so we need to explicitly invalidate the QSPI mapped memory to ensure we are
+        // comparing the local settings with the most recently persisted settings.
+        if(System::GetProgramMemoryRegion()
+           != System::MemoryRegion::INTERNAL_FLASH)
+        {
+            dsy_dma_invalidate_cache_for_buffer((int32_t *)data_ptr, sizeof(s));
+        }
+#endif
+
+        // Only actually save if the new data is different
+        // Use the `==operator` in custom SettingStruct to fine tune
+        // what may or may not trigger the erase/save.
+        auto storage_data = reinterpret_cast<SaveStruct *>(data_ptr);
+        if(settings_ != storage_data->user_data)
+        {
+            qspi_.Erase(address_offset_, address_offset_ + sizeof(s));
+            qspi_.Write(address_offset_, sizeof(s), (uint8_t *)&s);
+        }
+    }
+
+    QSPIHandle &  qspi_;
+    uint32_t      address_offset_;
+    SettingStruct default_settings_;
+    SettingStruct settings_;
+    State         state_;
+};
+
+} // namespace daisy

--- a/src/hal_conf_extra.h
+++ b/src/hal_conf_extra.h
@@ -24,5 +24,5 @@
 */
 
 // Once that is added we can repalce
-//#define DATA_CACHE_ENABLE
+#define DATA_CACHE_ENABLE
 

--- a/src/hal_conf_extra.h
+++ b/src/hal_conf_extra.h
@@ -3,6 +3,7 @@
 #define HAL_SDRAM_MODULE_ENABLED
 #define HAL_DMA_MODULE_ENABLED
 #define HAL_MDMA_MODULE_ENABLED
+#define HAL_QSPI_MODULE_ENABLED
 #define INSTRUCTION_CACHE_ENABLE
 
 // In order for the Cache to work and still allow the DMA to work 

--- a/src/utility/DaisySP/modules/reverbsc.cpp
+++ b/src/utility/DaisySP/modules/reverbsc.cpp
@@ -307,13 +307,13 @@ int ReverbSc::Process(const float &in,
 
     /* calculate "resultant junction pressure" and mix to input signals */
 
-    a_in_l = a_out_l = a_out_r = 0.0;
+    a_in_l = a_out_l = 0.0;
     for(n = 0; n < 8; n++)
     {
         a_in_l += delay_lines_[n].filter_state;
     }
     a_in_l *= kJpScale;
-    a_in_l = a_in_l + in1;
+    a_in_l = a_in_l + in;
 
     /* loop through all delay lines */
 
@@ -397,14 +397,7 @@ int ReverbSc::Process(const float &in,
 
         /* mix to output */
 
-        if(n & 1)
-        {
-            a_out_r += v0;
-        }
-        else
-        {
-            a_out_l += v0;
-        }
+        a_out_l += v0;
 
         /* start next random line segment if current one has reached endpoint */
 
@@ -413,8 +406,7 @@ int ReverbSc::Process(const float &in,
             NextRandomLineseg(lp, n);
         }
     }
-    /* someday, use a_out_r for multimono out */
 
-    *out1 = a_out_l * kOutputGain;
+    *out = a_out_l * kOutputGain;
     return REVSC_OK;
 }

--- a/src/utility/DaisySP/modules/reverbsc.h
+++ b/src/utility/DaisySP/modules/reverbsc.h
@@ -44,6 +44,10 @@ class ReverbSc
     */
     int Init(float sample_rate);
 
+    /** Process the input through the reverb, and updates values of out with the new processed signal.
+    */
+    int Process(const float &in, float *out);
+
     /** Process the input through the reverb, and updates values of out1, and out2 with the new processed signal.
     */
     int Process(const float &in1, const float &in2, float *out1, float *out2);

--- a/src/utility/flash_IS25LP064A.h
+++ b/src/utility/flash_IS25LP064A.h
@@ -1,0 +1,184 @@
+#pragma once
+
+#ifndef IS25LP064A_H
+#define IS25LP064A_H /**< & */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+#define IS25LP064A_FLASH_SIZE \
+    0x800000 /**< 2 * 8 MBits => 1 * 1MBytes => 1MBytes*/
+#define IS25LP064A_BLOCK_SIZE 0x10000 /**< 2 * 1024 sectors of 64KBytes */
+#define IS25LP064A_SECTOR_SIZE 0x1000 /**< 2 * 16384 subsectors of 4kBytes */
+#define IS25LP064A_PAGE_SIZE 0x100    /**< 2 * 262144 pages of 256 bytes */
+
+#define IS25LP064A_DUMMY_CYCLES_READ_QUAD 8     /**< & */
+#define IS25LP064A_DUMMY_CYCLES_READ 8          /**< & */
+#define IS25LP064A_DUMMY_CYCLES_READ_DTR 6      /**< & */
+#define IS25LP064A_DUMMY_CYCLES_READ_QUAD_DTR 6 /**< & */
+
+
+#define IS25LP064A_DIE_ERASE_MAX_TIME 460000 /**< & */
+#define IS25LP064A_BLOCK_ERASE_MAX_TIME 1000 /**< & */
+#define IS25LP064A_SECTOR_ERASE_MAX_TIME 400 /**< & */
+
+    /**
+     * @brief  IS25LP08D Commands  
+     */
+
+    /** @addtogroup flash
+    @{
+    */
+
+/** Low Power Modes */
+#define ENTER_DEEP_POWER_DOWN 0XB9 /**< & */
+#define EXIT_DEEP_POWER_DOWN 0XB9  /**< & */
+
+/** Reset Operations */
+#define RESET_ENABLE_CMD 0x66
+#define RESET_MEMORY_CMD 0x99 /**< & */
+
+    /** Identification Operations */
+#define READ_ID_CMD 0xAB
+#define READ_ID_CMD2 0x9F                      /**< & */
+#define MULTIPLE_IO_READ_ID_CMD 0xAF           /**< & */
+#define READ_SERIAL_FLASH_DISCO_PARAM_CMD 0x5A /**< & */
+#define READ_MANUFACT_AND_ID 0x90              /**< & */
+#define READ_UNIQUE_ID 0x4B                    /**< & */
+
+#define NO_OP 0x00 /**< Cancels Reset Enable */
+
+#define SECTOR_UNLOCK 0x26 /**< & */
+#define SECTOR_LOCK 0x24   /**< & */
+
+/** Security Information Row */
+#define INFO_ROW_ERASE_CMD 0x64   /**< & */
+#define INFO_ROW_PROGRAM_CMD 0x62 /**< & */
+#define INFO_ROW_READ_CMD 0x68    /**< & */
+
+    /** Read Operations */
+#define READ_CMD 0x03
+
+#define FAST_READ_CMD 0x0B     /**< & */
+#define FAST_READ_DTR_CMD 0x0D /**< & */
+
+#define DUAL_OUT_FAST_READ_CMD 0x3B /**< & */
+
+#define DUAL_INOUT_FAST_READ_CMD 0xBB     /**< & */
+#define DUAL_INOUT_FAST_READ_DTR_CMD 0xBD /**< & */
+
+#define QUAD_OUT_FAST_READ_CMD 0x6B /**< & */
+
+#define QUAD_INOUT_FAST_READ_CMD 0xEB     /**< & */
+#define QUAD_INOUT_FAST_READ_DTR_CMD 0xED /**< & */
+
+    /** Write Operations */
+#define WRITE_ENABLE_CMD 0x06
+#define WRITE_DISABLE_CMD 0x04 /**< & */
+
+    /** Register Operations */
+#define READ_STATUS_REG_CMD 0x05
+#define WRITE_STATUS_REG_CMD 0x01 /**< & */
+
+#define READ_FUNCTION_REGISTER 0X48  /**< & */
+#define WRITE_FUNCTION_REGISTER 0x42 /**< & */
+
+#define WRITE_READ_PARAM_REG_CMD 0xC0 /**< & */
+
+    /** Page Program Operations */
+#define PAGE_PROG_CMD 0x02
+
+#define QUAD_IN_PAGE_PROG_CMD 0x32     /**< & */
+#define EXT_QUAD_IN_PAGE_PROG_CMD 0x38 /**< & */
+
+    /** Erase Operations */
+#define SECTOR_ERASE_CMD 0xd7     //already defined in 80
+#define SECTOR_ERASE_QPI_CMD 0x20 /**< & */
+
+#define BLOCK_ERASE_CMD 0xD8     /**< & */
+#define BLOCK_ERASE_32K_CMD 0x52 /**< & */
+
+#define CHIP_ERASE_CMD 0xC7     /**< & */
+#define EXT_CHIP_ERASE_CMD 0x60 /**< & */
+
+#define PROG_ERASE_RESUME_CMD 0x7A     /**< & */
+#define EXT_PROG_ERASE_RESUME_CMD 0x30 /**< & */
+
+#define PROG_ERASE_SUSPEND_CMD 0x75     /**< & */
+#define EXT_PROG_ERASE_SUSPEND_CMD 0xB0 /**< & */
+
+    /** Quad Operations */
+#define ENTER_QUAD_CMD 0x35
+#define EXIT_QUAD_CMD 0xF5 /**< & */
+
+    /** 
+                      * @brief  IS25LP08D Registers  
+                      */
+    /* Status Register */
+#define IS25LP064A_SR_WIP ((uint8_t)0x01)  /*!< Write in progress */
+#define IS25LP064A_SR_WREN ((uint8_t)0x02) /*!< Write enable latch */
+//#define IS25LP064A_SR_BLOCKPR                  ((uint8_t)0x5C)    /*!< Block protected against program and erase operations */
+//#define IS25LP064A_SR_PRBOTTOM                 ((uint8_t)0x20)    /*!< Protected memory area defined by BLOCKPR starts from top or bottom */
+#define IS25LP064A_SR_SRWREN \
+    ((uint8_t)0x80) /*!< Status register write enable/disable */
+#define IS25LP064A_SR_QE ((uint8_t)0x40) /**< & */
+
+    /* Non volatile Configuration Register */
+#define IS25LP064A_NVCR_NBADDR \
+    ((uint16_t)0x0001) /*!< 3-bytes or 4-bytes addressing */
+#define IS25LP064A_NVCR_SEGMENT \
+    ((uint16_t)0x0002) /*!< Upper or lower 128Mb segment selected by default */
+#define IS25LP064A_NVCR_DUAL ((uint16_t)0x0004) /*!< Dual I/O protocol */
+#define IS25LP064A_NVCR_QUAB ((uint16_t)0x0008) /*!< Quad I/O protocol */
+#define IS25LP064A_NVCR_RH ((uint16_t)0x0010)   /*!< Reset/hold */
+#define IS25LP064A_NVCR_DTRP \
+    ((uint16_t)0x0020) /*!< Double transfer rate protocol */
+#define IS25LP064A_NVCR_ODS ((uint16_t)0x01C0) /*!< Output driver strength */
+#define IS25LP064A_NVCR_XIP \
+    ((uint16_t)0x0E00) /*!< XIP mode at power-on reset */
+#define IS25LP064A_NVCR_NB_DUMMY \
+    ((uint16_t)0xF000) /*!< Number of dummy clock cycles */
+
+    /* Volatile Configuration Register */
+#define IS25LP064A_VCR_WRAP ((uint8_t)0x03) /*!< Wrap */
+#define IS25LP064A_VCR_XIP ((uint8_t)0x08)  /*!< XIP */
+#define IS25LP064A_VCR_NB_DUMMY \
+    ((uint8_t)0xF0) /*!< Number of dummy clock cycles */
+
+    /* Extended Address Register */
+#define IS25LP064A_EAR_HIGHEST_SE \
+    ((uint8_t)0x03) /*!< Select the Highest 128Mb segment */
+#define IS25LP064A_EAR_THIRD_SEG \
+    ((uint8_t)0x02) /*!< Select the Third 128Mb segment */
+#define IS25LP064A_EAR_SECOND_SEG \
+    ((uint8_t)0x01) /*!< Select the Second 128Mb segment */
+#define IS25LP064A_EAR_LOWEST_SEG \
+    ((uint8_t)0x00) /*!< Select the Lowest 128Mb segment (default) */
+
+    /* Enhanced Volatile Configuration Register */
+#define IS25LP064A_EVCR_ODS ((uint8_t)0x07) /*!< Output driver strength */
+#define IS25LP064A_EVCR_RH ((uint8_t)0x10)  /*!< Reset/hold */
+#define IS25LP064A_EVCR_DTRP \
+    ((uint8_t)0x20) /*!< Double transfer rate protocol */
+#define IS25LP064A_EVCR_DUAL ((uint8_t)0x40) /*!< Dual I/O protocol */
+#define IS25LP064A_EVCR_QUAD ((uint8_t)0x80) /*!< Quad I/O protocol */
+
+    /* Flag Status Register */
+#define IS25LP064A_FSR_NBADDR \
+    ((uint8_t)0x01) /*!< 3-bytes or 4-bytes addressing */
+#define IS25LP064A_FSR_PRERR ((uint8_t)0x02) /*!< Protection error */
+#define IS25LP064A_FSR_PGSUS ((uint8_t)0x04) /*!< Program operation suspended */
+#define IS25LP064A_FSR_PGERR ((uint8_t)0x10) /*!< Program error */
+#define IS25LP064A_FSR_ERERR ((uint8_t)0x20) /*!< Erase error */
+#define IS25LP064A_FSR_ERSUS ((uint8_t)0x40) /*!< Erase operation suspended */
+#define IS25LP064A_FSR_READY \
+    ((uint8_t)0x80) /*!< Ready or command in progress */
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+/** @} */

--- a/src/utility/flash_IS25LP080D.h
+++ b/src/utility/flash_IS25LP080D.h
@@ -1,0 +1,201 @@
+#pragma once
+
+#ifndef IS25LP080D_H
+#define IS25LP080D_H
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+#define IS25LP080D_FLASH_SIZE \
+    0x100000 /**< 2 * 8 MBits => 1 * 1MBytes => 1MBytes */
+#define IS25LP080D_BLOCK_SIZE 0x10000 /**< 2 * 1024 blocks of 64KBytes */
+#define IS25LP080D_SECTOR_SIZE 0x1000 /**< 2 * 16384 sectors of 4kBytes */
+#define IS25LP080D_PAGE_SIZE 0x100    /**< 2 * 262144 pages of 256 bytes */
+
+#define IS25LP080D_DUMMY_CYCLES_READ_QUAD 8     /**< & */
+#define IS25LP080D_DUMMY_CYCLES_READ 8          /**< & */
+#define IS25LP080D_DUMMY_CYCLES_READ_DTR 6      /**< & */
+#define IS25LP080D_DUMMY_CYCLES_READ_QUAD_DTR 6 /**< & */
+
+
+#define IS25LP080D_DIE_ERASE_MAX_TIME 460000 /**< & */
+#define IS25LP080D_BLOCK_ERASE_MAX_TIME 1000 /**< & */
+#define IS25LP080D_SECTOR_ERASE_MAX_TIME 400 /**< & */
+
+    /**
+     * @brief  IS25LP08D Commands  
+     */
+
+    /** @addtogroup flash
+    @{
+    */
+
+//register stuff is CRAZY
+
+/** Low Power Modes */
+#define ENTER_DEEP_POWER_DOWN 0XB9 /**< & */
+#define EXIT_DEEP_POWER_DOWN 0XB9  /**< & */
+
+/** Reset Operations */
+#define RESET_ENABLE_CMD 0x66
+#define RESET_MEMORY_CMD 0x99 /**< & */
+
+    /** Identification Operations */
+#define READ_ID_CMD 0xAB
+#define READ_ID_CMD2 0x9F                      /**< & */
+#define MULTIPLE_IO_READ_ID_CMD 0xAF           /**< & */
+#define READ_SERIAL_FLASH_DISCO_PARAM_CMD 0x5A /**< & */
+#define READ_MANUFACT_AND_ID 0x90              /**< & */
+#define READ_UNIQUE_ID 0x4B                    /**< & */
+
+#define NO_OP 0x00 /**< Cancels Reset Enable */
+
+#define SECTOR_UNLOCK 0x26 /**< & */
+#define SECTOR_LOCK 0x24   /**< & */
+
+    /** Security Information Row */
+#define INFO_ROW_ERASE_CMD 0x64   /**< & */
+#define INFO_ROW_PROGRAM_CMD 0x62 /**< & */
+#define INFO_ROW_READ_CMD 0x68    /**< & */
+
+/** Page Operations */
+#define PAGE_PROG_CMD 0x02
+
+#define QUAD_IN_PAGE_PROG_CMD 0x32     /**< & */
+#define EXT_QUAD_IN_PAGE_PROG_CMD 0x38 /**< & */
+
+    /** Read Operations */
+#define READ_CMD 0x03
+
+#define FAST_READ_CMD 0x0B     /**< & */
+#define FAST_READ_DTR_CMD 0x0D /**< & */
+
+#define DUAL_OUT_FAST_READ_CMD 0x3B /**< & */
+
+#define DUAL_INOUT_FAST_READ_CMD 0xBB     /**< & */
+#define DUAL_INOUT_FAST_READ_DTR_CMD 0xBD /**< & */
+
+#define QUAD_OUT_FAST_READ_CMD 0x6B /**< & */
+
+#define QUAD_INOUT_FAST_READ_CMD 0xEB     /**< & */
+#define QUAD_INOUT_FAST_READ_DTR_CMD 0xED /**< & */
+
+    /** Write Operations */
+#define WRITE_ENABLE_CMD 0x06
+#define WRITE_DISABLE_CMD 0x04 /**< & */
+
+    /** Register Operations */
+#define READ_STATUS_REG_CMD 0x05
+#define WRITE_STATUS_REG_CMD 0x01 /**< & */
+
+#define READ_FUNCTION_REGISTER 0X48  /**< & */
+#define WRITE_FUNCTION_REGISTER 0x42 /**< & */
+
+#define READ_READ_PARAM_REG_CMD 0x61  /**< & */
+#define READ_EXT_READ_PARAM_CMD 0x81  /**< & */
+#define CLEAR_EXT_READ_PARAM_CMD 0x82 /**< &  */
+
+#define WRITE_READ_PARAM_REG_CMD 0xC0     /**< volatile */
+#define WRITE_NV_READ_PARAM_REG_CMD 0x65  /**< non-volatile */
+#define EXT_WRITE_READ_PARAM_REG_CMD 0x63 /**< volatile */
+
+#define WRITE_EXT_READ_PARAM_REG_CMD 0x83    /**< volatile */
+#define WRITE_EXT_NV_READ_PARAM_REG_CMD 0x85 /**< non-volatile */
+
+    /** Program Operations */
+#define PAGE_PROG_CMD 0x02
+
+#define QUAD_IN_FAST_PROG_CMD 0x32     /**< & */
+#define EXT_QUAD_IN_FAST_PROG_CMD 0x38 /**< & */
+
+    /** Erase Operations */
+#define SECTOR_ERASE_CMD 0xd7
+#define SECTOR_ERASE_QPI_CMD 0x20 /**< & */
+
+#define BLOCK_ERASE_CMD 0xD8     /**< & */
+#define BLOCK_ERASE_32K_CMD 0x52 /**< & */
+
+#define CHIP_ERASE_CMD 0xC7     /**< & */
+#define EXT_CHIP_ERASE_CMD 0x60 /**< & */
+
+#define PROG_ERASE_RESUME_CMD 0x7A     /**< & */
+#define EXT_PROG_ERASE_RESUME_CMD 0x30 /**< & */
+
+#define PROG_ERASE_SUSPEND_CMD 0x75     /**< & */
+#define EXT_PROG_ERASE_SUSPEND_CMD 0xB0 /**< & */
+
+    /** Quad Operations */
+#define ENTER_QUAD_CMD 0x35
+#define EXIT_QUAD_CMD 0xF5 /**< & */
+
+    /** 
+                      * @brief  IS25LP08D Registers  
+                      */
+    /** Status Register */
+#define IS25LP080D_SR_WIP ((uint8_t)0x01)  /*!< Write in progress */
+#define IS25LP080D_SR_WREN ((uint8_t)0x02) /*!< Write enable latch */
+//#define IS25LP080D_SR_BLOCKPR                  ((uint8_t)0x5C)    /*!< Block protected against program and erase operations */
+//#define IS25LP080D_SR_PRBOTTOM                 ((uint8_t)0x20)    /*!< Protected memory area defined by BLOCKPR starts from top or bottom */
+#define IS25LP080D_SR_SRWREN \
+    ((uint8_t)0x80) /*!< Status register write enable/disable */
+#define IS25LP080D_SR_QE ((uint8_t)0x40) /**< & */
+
+    /* Non volatile Configuration Register */
+#define IS25LP080D_NVCR_NBADDR \
+    ((uint16_t)0x0001) /*!< 3-bytes or 4-bytes addressing */
+#define IS25LP080D_NVCR_SEGMENT \
+    ((uint16_t)0x0002) /*!< Upper or lower 128Mb segment selected by default */
+#define IS25LP080D_NVCR_DUAL ((uint16_t)0x0004) /*!< Dual I/O protocol */
+#define IS25LP080D_NVCR_QUAB ((uint16_t)0x0008) /*!< Quad I/O protocol */
+#define IS25LP080D_NVCR_RH ((uint16_t)0x0010)   /*!< Reset/hold */
+#define IS25LP080D_NVCR_DTRP \
+    ((uint16_t)0x0020) /*!< Double transfer rate protocol */
+#define IS25LP080D_NVCR_ODS ((uint16_t)0x01C0) /*!< Output driver strength */
+#define IS25LP080D_NVCR_XIP \
+    ((uint16_t)0x0E00) /*!< XIP mode at power-on reset */
+#define IS25LP080D_NVCR_NB_DUMMY \
+    ((uint16_t)0xF000) /*!< Number of dummy clock cycles */
+
+    /* Volatile Configuration Register */
+#define IS25LP080D_VCR_WRAP ((uint8_t)0x03) /*!< Wrap */
+#define IS25LP080D_VCR_XIP ((uint8_t)0x08)  /*!< XIP */
+#define IS25LP080D_VCR_NB_DUMMY \
+    ((uint8_t)0xF0) /*!< Number of dummy clock cycles */
+
+    /* Extended Address Register */
+#define IS25LP080D_EAR_HIGHEST_SE \
+    ((uint8_t)0x03) /*!< Select the Highest 128Mb segment */
+#define IS25LP080D_EAR_THIRD_SEG \
+    ((uint8_t)0x02) /*!< Select the Third 128Mb segment */
+#define IS25LP080D_EAR_SECOND_SEG \
+    ((uint8_t)0x01) /*!< Select the Second 128Mb segment */
+#define IS25LP080D_EAR_LOWEST_SEG \
+    ((uint8_t)0x00) /*!< Select the Lowest 128Mb segment (default) */
+
+    /* Enhanced Volatile Configuration Register */
+#define IS25LP080D_EVCR_ODS ((uint8_t)0x07) /*!< Output driver strength */
+#define IS25LP080D_EVCR_RH ((uint8_t)0x10)  /*!< Reset/hold */
+#define IS25LP080D_EVCR_DTRP \
+    ((uint8_t)0x20) /*!< Double transfer rate protocol */
+#define IS25LP080D_EVCR_DUAL ((uint8_t)0x40) /*!< Dual I/O protocol */
+#define IS25LP080D_EVCR_QUAD ((uint8_t)0x80) /*!< Quad I/O protocol */
+
+    /* Flag Status Register */
+#define IS25LP080D_FSR_NBADDR \
+    ((uint8_t)0x01) /*!< 3-bytes or 4-bytes addressing */
+#define IS25LP080D_FSR_PRERR ((uint8_t)0x02) /*!< Protection error */
+#define IS25LP080D_FSR_PGSUS ((uint8_t)0x04) /*!< Program operation suspended */
+#define IS25LP080D_FSR_PGERR ((uint8_t)0x10) /*!< Program error */
+#define IS25LP080D_FSR_ERERR ((uint8_t)0x20) /*!< Erase error */
+#define IS25LP080D_FSR_ERSUS ((uint8_t)0x40) /*!< Erase operation suspended */
+#define IS25LP080D_FSR_READY \
+    ((uint8_t)0x80) /*!< Ready or command in progress */
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+/** @} */

--- a/src/utility/qspi.cpp
+++ b/src/utility/qspi.cpp
@@ -1,0 +1,1035 @@
+#include "qspi.h"
+#include "system.h"
+#include "flash_IS25LP080D.h"
+#include "flash_IS25LP064A.h"
+extern "C"
+{
+#include "hal_map.h"
+}
+
+// TODO: Add handling for alternate device types,
+//        This will be a thing much sooner than anticipated
+//        due to upgrading the RAM size for the new 4MB chip.
+// TODO: AutopollingMemReady only works for 1-Line, not 4-Line
+
+#define RETURN_IF_ERR(func) \
+    if(func != Result::OK)  \
+        return Result::ERR;
+
+#define ERR_RECOVERY(err)                 \
+    SetMode(Config::Mode::MEMORY_MAPPED); \
+    status_ = err;                        \
+    return Result::ERR;
+
+#define ERR_SIMPLE(err) \
+    status_ = err;      \
+    return Result::ERR;
+
+
+namespace daisy
+{
+/** Private implementation for QSPIHandle */
+class QSPIHandle::Impl
+{
+  public:
+    QSPIHandle::Result Init(const QSPIHandle::Config& config);
+
+    const QSPIHandle::Config& GetConfig() const { return config_; }
+
+    QSPIHandle::Result DeInit();
+
+    QSPIHandle::Result WritePage(uint32_t address,
+                                 uint32_t size,
+                                 uint8_t* buffer,
+                                 bool     reset_mode = true);
+
+    QSPIHandle::Result Write(uint32_t address, uint32_t size, uint8_t* buffer);
+
+    QSPIHandle::Result Erase(uint32_t start_addr, uint32_t end_addr);
+
+    QSPIHandle::Result EraseSector(uint32_t address);
+
+    uint32_t GetPin(size_t pin);
+
+    GPIO_TypeDef* GetPort(size_t pin);
+
+    QSPI_HandleTypeDef* GetHalHandle();
+
+    size_t GetNumPins() { return pin_count_; }
+
+    Status GetStatus() { return status_; }
+
+    void* GetData(uint32_t offset)
+    {
+        return (void*)(0x90000000 + (offset & 0x0fffffff));
+    }
+
+  private:
+    QSPIHandle::Result ResetMemory();
+
+    QSPIHandle::Result DummyCyclesConfig(QSPIHandle::Config::Device device);
+
+    QSPIHandle::Result WriteEnable();
+
+    QSPIHandle::Result QuadEnable();
+
+    QSPIHandle::Result EnableMemoryMappedMode();
+
+    QSPIHandle::Result AutopollingMemReady(uint32_t timeout);
+
+    QSPIHandle::Result SetMode(Config::Mode mode);
+
+    QSPIHandle::Result CheckProgramMemory();
+
+    // These functions are defined, but we haven't added the ability to switch to quad mode. So they're currently unused.
+    QSPIHandle::Result EnterQuadMode() __attribute__((unused));
+    QSPIHandle::Result ExitQuadMode() __attribute__((unused));
+    uint8_t            GetStatusRegister() __attribute__((unused));
+
+    QSPIHandle::Config config_;
+    QSPI_HandleTypeDef halqspi_;
+    Status             status_;
+
+    static constexpr size_t pin_count_
+        = sizeof(QSPIHandle::Config::pin_config) / sizeof(dsy_gpio_pin);
+    // Data structure for easy hal initialization
+    dsy_gpio_pin* pin_config_arr_[pin_count_] = {&config_.pin_config.io0,
+                                                 &config_.pin_config.io1,
+                                                 &config_.pin_config.io2,
+                                                 &config_.pin_config.io3,
+                                                 &config_.pin_config.clk,
+                                                 &config_.pin_config.ncs};
+};
+
+
+// ================================================================
+// Global reference to the handle for interfacing with hal
+// ================================================================
+
+static QSPIHandle::Impl qspi_impl;
+
+
+QSPIHandle::Result QSPIHandle::Impl::Init(const QSPIHandle::Config& config)
+{
+    RETURN_IF_ERR(CheckProgramMemory());
+    // Set Handle Settings     o
+
+    config_     = config;
+    auto device = config_.device;
+    auto mode   = config_.mode;
+
+    if(HAL_QSPI_DeInit(&halqspi_) != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    //HAL_QSPI_MspInit(&dsy_qspi_handle);     // I think this gets called a in HAL_QSPI_Init();
+    // Set Initialization values for the QSPI Peripheral
+    uint32_t flash_size;
+    switch(device)
+    {
+        case QSPIHandle::Config::Device::IS25LP080D:
+            flash_size = IS25LP080D_FLASH_SIZE;
+            break;
+        case QSPIHandle::Config::Device::IS25LP064A:
+            flash_size = IS25LP064A_FLASH_SIZE;
+            break;
+        default: flash_size = IS25LP080D_FLASH_SIZE; break;
+    }
+    halqspi_.Instance = QUADSPI;
+    //dsy_qspi_handle.Init.ClockPrescaler = 7;
+    //dsy_qspi_handle.Init.ClockPrescaler = 7;
+    //dsy_qspi_handle.Init.ClockPrescaler = 2; // Conservative setting for now. Signal gets very weak faster than this.
+    halqspi_.Init.ClockPrescaler     = 1;
+    halqspi_.Init.FifoThreshold      = 1;
+    halqspi_.Init.SampleShifting     = QSPI_SAMPLE_SHIFTING_NONE;
+    halqspi_.Init.FlashSize          = POSITION_VAL(flash_size) - 1;
+    halqspi_.Init.ChipSelectHighTime = QSPI_CS_HIGH_TIME_2_CYCLE;
+    halqspi_.Init.FlashID            = QSPI_FLASH_ID_1;
+    halqspi_.Init.DualFlash          = QSPI_DUALFLASH_DISABLE;
+
+    if(HAL_QSPI_Init(&halqspi_) != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    if(ResetMemory() != QSPIHandle::Result::OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    //    uint8_t fifothresh = HAL_QSPI_GetFifoThreshold(&dsy_qspi_handle.hqspi);
+    //    uint8_t reg = 0;
+    //    reg = get_status_register(&dsy_qspi_handle);
+    if(DummyCyclesConfig(device) != QSPIHandle::Result::OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    // Once writing test with 1 Line is confirmed lets move this out, and update writing to use 4-line.
+    if(QuadEnable() != QSPIHandle::Result::OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+
+    if(mode == Config::Mode::MEMORY_MAPPED)
+    {
+        if(EnableMemoryMappedMode() != QSPIHandle::Result::OK)
+        {
+            ERR_SIMPLE(Status::E_HAL_ERROR);
+        }
+    }
+
+    return QSPIHandle::Result::OK;
+}
+
+
+QSPIHandle::Result QSPIHandle::Impl::DeInit()
+{
+    halqspi_.Instance = QUADSPI;
+    if(HAL_QSPI_DeInit(&halqspi_) != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    HAL_QSPI_MspDeInit(&halqspi_);
+    return QSPIHandle::Result::OK;
+}
+
+
+QSPIHandle::Result QSPIHandle::Impl::WritePage(uint32_t address,
+                                               uint32_t size,
+                                               uint8_t* buffer,
+                                               bool     reset_mode)
+{
+    RETURN_IF_ERR(CheckProgramMemory());
+    RETURN_IF_ERR(SetMode(Config::Mode::INDIRECT_POLLING));
+
+    QSPI_CommandTypeDef s_command;
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction       = PAGE_PROG_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_1_LINE;
+    s_command.AddressSize       = QSPI_ADDRESS_24_BITS;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_1_LINE;
+    s_command.DummyCycles       = 0;
+    s_command.NbData            = size <= 256 ? size : 256;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+    s_command.Address           = address;
+    if(WriteEnable() != QSPIHandle::Result::OK)
+    {
+        ERR_RECOVERY(Status::E_HAL_ERROR);
+    }
+    if(HAL_QSPI_Command(&halqspi_, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_RECOVERY(Status::E_HAL_ERROR);
+    }
+    if(HAL_QSPI_Transmit(
+           &halqspi_, (uint8_t*)buffer, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_RECOVERY(Status::E_HAL_ERROR);
+    }
+    if(AutopollingMemReady(HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != QSPIHandle::Result::OK)
+    {
+        ERR_RECOVERY(Status::E_HAL_ERROR);
+    }
+
+    if(reset_mode)
+        RETURN_IF_ERR(SetMode(Config::Mode::MEMORY_MAPPED));
+    return QSPIHandle::Result::OK;
+}
+
+
+QSPIHandle::Result
+QSPIHandle::Impl::Write(uint32_t address, uint32_t size, uint8_t* buffer)
+{
+    uint32_t NumOfPage = 0, NumOfSingle = 0, Addr = 0, count = 0, temp = 0;
+    uint32_t QSPI_DataNum    = 0;
+    uint32_t flash_page_size = IS25LP080D_PAGE_SIZE;
+    address                  = address & 0x0FFFFFFF;
+    Addr                     = address % flash_page_size;
+    count                    = flash_page_size - Addr;
+    NumOfPage                = size / flash_page_size;
+    NumOfSingle              = size % flash_page_size;
+
+    if(Addr == 0) /*!< Address is QSPI_PAGESIZE aligned  */
+    {
+        if(NumOfPage == 0) /*!< NumByteToWrite < QSPI_PAGESIZE */
+        {
+            QSPI_DataNum = size;
+            WritePage(address, QSPI_DataNum, buffer, false);
+        }
+        else /*!< Size > QSPI_PAGESIZE */
+        {
+            while(NumOfPage--)
+            {
+                QSPI_DataNum = flash_page_size;
+                WritePage(address, QSPI_DataNum, buffer, false);
+                address += flash_page_size;
+                buffer += flash_page_size;
+            }
+
+            QSPI_DataNum = NumOfSingle;
+            if(QSPI_DataNum > 0)
+                WritePage(address, QSPI_DataNum, buffer, false);
+        }
+    }
+    else /*!< Address is not QSPI_PAGESIZE aligned  */
+    {
+        if(NumOfPage == 0) /*!< Size < QSPI_PAGESIZE */
+        {
+            if(NumOfSingle > count) /*!< (Size + Address) > QSPI_PAGESIZE */
+            {
+                temp         = NumOfSingle - count;
+                QSPI_DataNum = count;
+                WritePage(address, QSPI_DataNum, buffer, false);
+                address += count;
+                buffer += count;
+                QSPI_DataNum = temp;
+                WritePage(address, QSPI_DataNum, buffer, false);
+            }
+            else
+            {
+                QSPI_DataNum = size;
+                WritePage(address, QSPI_DataNum, buffer, false);
+            }
+        }
+        else /*!< Size > QSPI_PAGESIZE */
+        {
+            size -= count;
+            NumOfPage    = size / flash_page_size;
+            NumOfSingle  = size % flash_page_size;
+            QSPI_DataNum = count;
+            WritePage(address, QSPI_DataNum, buffer, false);
+            address += count;
+            buffer += count;
+
+            while(NumOfPage--)
+            {
+                QSPI_DataNum = flash_page_size;
+                WritePage(address, QSPI_DataNum, buffer, false);
+                address += flash_page_size;
+                buffer += flash_page_size;
+            }
+
+            if(NumOfSingle != 0)
+            {
+                QSPI_DataNum = NumOfSingle;
+                WritePage(address, QSPI_DataNum, buffer, false);
+            }
+        }
+    }
+
+    RETURN_IF_ERR(SetMode(Config::Mode::MEMORY_MAPPED));
+    return QSPIHandle::Result::OK;
+}
+
+
+QSPIHandle::Result QSPIHandle::Impl::Erase(uint32_t start_addr,
+                                           uint32_t end_addr)
+{
+    uint32_t block_addr;
+    uint32_t block_size = IS25LP080D_SECTOR_SIZE; // 4kB blocks for now.
+    // 64kB chunks for now.
+    start_addr = start_addr - (start_addr % block_size);
+    while(end_addr > start_addr)
+    {
+        block_addr = start_addr & 0x0FFFFFFF;
+        if(EraseSector(block_addr) != QSPIHandle::Result::OK)
+        {
+            ERR_RECOVERY(Status::E_HAL_ERROR);
+        }
+        start_addr += block_size;
+    }
+    return QSPIHandle::Result::OK;
+}
+
+
+QSPIHandle::Result QSPIHandle::Impl::EraseSector(uint32_t address)
+{
+    uint8_t             use_qpi = 0;
+    QSPI_CommandTypeDef s_command;
+    if(use_qpi)
+    {
+        s_command.InstructionMode = QSPI_INSTRUCTION_4_LINES;
+        s_command.Instruction     = SECTOR_ERASE_QPI_CMD;
+        s_command.AddressMode     = QSPI_ADDRESS_4_LINES;
+    }
+    else
+    {
+        s_command.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+        s_command.Instruction     = SECTOR_ERASE_CMD;
+        s_command.AddressMode     = QSPI_ADDRESS_1_LINE;
+    }
+    s_command.AddressSize       = QSPI_ADDRESS_24_BITS;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_NONE;
+    s_command.DummyCycles       = 0;
+    s_command.NbData            = 1;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+    s_command.Address           = address;
+
+    RETURN_IF_ERR(CheckProgramMemory());
+    // Erasing takes a long time anyway, so not much point trying to
+    // minimize reinitializations
+    RETURN_IF_ERR(SetMode(Config::Mode::INDIRECT_POLLING));
+
+    if(WriteEnable() != QSPIHandle::Result::OK)
+    {
+        ERR_RECOVERY(Status::E_HAL_ERROR);
+    }
+    if(HAL_QSPI_Command(&halqspi_, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_RECOVERY(Status::E_HAL_ERROR);
+    }
+    if(AutopollingMemReady(HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != QSPIHandle::Result::OK)
+    {
+        ERR_RECOVERY(Status::E_HAL_ERROR);
+    }
+
+    RETURN_IF_ERR(SetMode(Config::Mode::MEMORY_MAPPED));
+    return QSPIHandle::Result::OK;
+}
+
+
+QSPIHandle::Result QSPIHandle::Impl::ResetMemory()
+{
+    QSPI_CommandTypeDef s_command;
+
+    /* Initialize the reset enable command */
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction       = RESET_ENABLE_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_NONE;
+    s_command.DummyCycles       = 0;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+
+    /* Send the command */
+    if(HAL_QSPI_Command(&halqspi_, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+
+    /* Send the reset memory command */
+    s_command.Instruction = RESET_MEMORY_CMD;
+    if(HAL_QSPI_Command(&halqspi_, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+
+    /* Configure automatic polling mode to wait the memory is ready */
+    if(AutopollingMemReady(HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != QSPIHandle::Result::OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    return QSPIHandle::Result::OK;
+}
+
+
+QSPIHandle::Result
+QSPIHandle::Impl::DummyCyclesConfig(QSPIHandle::Config::Device device)
+{
+    QSPI_CommandTypeDef s_command;
+    uint16_t            reg     = 0;
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.AddressMode       = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_1_LINE;
+    s_command.DummyCycles       = 0;
+    s_command.NbData            = 1;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+    if(device == QSPIHandle::Config::Device::IS25LP080D)
+    {
+        /* Initialize the read volatile configuration register command */
+        s_command.Instruction = READ_READ_PARAM_REG_CMD;
+
+        /* Configure the command */
+        if(HAL_QSPI_Command(
+               &halqspi_, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+           != HAL_OK)
+        {
+            ERR_SIMPLE(Status::E_HAL_ERROR);
+        }
+
+        /* Reception of the data */
+        if(HAL_QSPI_Receive(
+               &halqspi_, (uint8_t*)(&reg), HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+           != HAL_OK)
+        {
+            ERR_SIMPLE(Status::E_HAL_ERROR);
+        }
+        MODIFY_REG(reg, 0x78, (IS25LP080D_DUMMY_CYCLES_READ_QUAD << 3));
+        /* Enable write operations */
+        if(WriteEnable() != QSPIHandle::Result::OK)
+        {
+            ERR_SIMPLE(Status::E_HAL_ERROR);
+        }
+    }
+    else
+    {
+        // Only volatile Read Params on 16MB chip.
+        // Explicitly set:
+        // Burst Length: 8 bytes (0, 0)
+        // Wrap Enable: 0
+        // Dummy Cycles: (Config 3, bits 1 0)
+        // Drive Strength (50%, bits 1 1 1)
+        // Byte to write: 0b11110000 (0xF0)
+        // TODO: Probably expand Burst to maximum if that works out.
+
+        reg = 0xF0;
+    }
+
+
+    /* Update volatile configuration register (with new dummy cycles) */
+    s_command.Instruction = WRITE_READ_PARAM_REG_CMD;
+
+    /* Configure the write volatile configuration register command */
+    if(HAL_QSPI_Command(&halqspi_, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+
+    /* Transmission of the data */
+    if(HAL_QSPI_Transmit(
+           &halqspi_, (uint8_t*)(&reg), HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+
+    /* Configure automatic polling mode to wait the memory is ready */
+    if(AutopollingMemReady(HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != QSPIHandle::Result::OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    return QSPIHandle::Result::OK;
+}
+
+
+QSPIHandle::Result QSPIHandle::Impl::WriteEnable()
+{
+    QSPI_CommandTypeDef     s_command;
+    QSPI_AutoPollingTypeDef s_config;
+
+    /* Enable write operations */
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction       = WRITE_ENABLE_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_NONE;
+    s_command.DummyCycles       = 0;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+
+    RETURN_IF_ERR(CheckProgramMemory());
+
+    if(HAL_QSPI_Command(&halqspi_, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+
+    /* Configure automatic polling mode to wait for write enabling */
+    //        s_config.Match           = IS25LP080D_SR_WREN | (IS25LP080D_SR_WREN << 8);
+    //        s_config.Mask            = IS25LP080D_SR_WREN | (IS25LP080D_SR_WREN << 8);
+    s_config.MatchMode       = QSPI_MATCH_MODE_AND;
+    s_config.Match           = IS25LP080D_SR_WREN;
+    s_config.Mask            = IS25LP080D_SR_WREN;
+    s_config.Interval        = 0x10;
+    s_config.StatusBytesSize = 1;
+    s_config.AutomaticStop   = QSPI_AUTOMATIC_STOP_ENABLE;
+
+    s_command.Instruction = READ_STATUS_REG_CMD;
+    s_command.DataMode    = QSPI_DATA_1_LINE;
+
+    if(HAL_QSPI_AutoPolling(
+           &halqspi_, &s_command, &s_config, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    return QSPIHandle::Result::OK;
+}
+
+
+QSPIHandle::Result QSPIHandle::Impl::QuadEnable()
+{
+    QSPI_CommandTypeDef     s_command;
+    QSPI_AutoPollingTypeDef s_config;
+    uint8_t                 reg = 0;
+
+    /* Enable write operations */
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction       = WRITE_STATUS_REG_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_1_LINE;
+    s_command.DummyCycles       = 0;
+    s_command.NbData            = 1;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+
+    /* Enable write operations */
+    if(WriteEnable() != QSPIHandle::Result::OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+
+    if(HAL_QSPI_Command(&halqspi_, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+
+
+    //    reg = 0;
+    //    MODIFY_REG(reg,
+    //        0xF0,
+    //        (IS25LP08D_SR_QE));
+    reg = IS25LP080D_SR_QE; // Set QE bit  to 1
+    /* Transmission of the data */
+    if(HAL_QSPI_Transmit(
+           &halqspi_, (uint8_t*)(&reg), HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+
+    /* Configure automatic polling mode to wait for write enabling */
+    //    s_config.Match           = IS25LP08D_SR_WREN | (IS25LP08D_SR_WREN << 8);
+    //    s_config.Mask            = IS25LP08D_SR_WREN | (IS25LP08D_SR_WREN << 8);
+    //    s_config.MatchMode       = QSPI_MATCH_MODE_AND;
+    //    s_config.StatusBytesSize = 2;
+    s_config.Match           = IS25LP080D_SR_QE;
+    s_config.Mask            = IS25LP080D_SR_QE;
+    s_config.MatchMode       = QSPI_MATCH_MODE_AND;
+    s_config.StatusBytesSize = 1;
+
+    s_config.Interval      = 0x10;
+    s_config.AutomaticStop = QSPI_AUTOMATIC_STOP_ENABLE;
+
+    s_command.Instruction = READ_STATUS_REG_CMD;
+    s_command.DataMode    = QSPI_DATA_1_LINE;
+
+    if(HAL_QSPI_AutoPolling(
+           &halqspi_, &s_command, &s_config, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+
+    /* Configure automatic polling mode to wait the memory is ready */
+    if(AutopollingMemReady(HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != QSPIHandle::Result::OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    return QSPIHandle::Result::OK;
+}
+
+
+QSPIHandle::Result QSPIHandle::Impl::EnableMemoryMappedMode()
+{
+    QSPI_CommandTypeDef      s_command;
+    QSPI_MemoryMappedTypeDef s_mem_mapped_cfg;
+
+    /* Configure the command for the read instruction */
+    s_command.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction     = QUAD_INOUT_FAST_READ_CMD;
+    s_command.AddressMode     = QSPI_ADDRESS_4_LINES;
+    s_command.AddressSize     = QSPI_ADDRESS_24_BITS;
+    //    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    //s_command.DummyCycles       = IS25LP080D_DUMMY_CYCLES_READ_QUAD;
+    s_command.AlternateByteMode  = QSPI_ALTERNATE_BYTES_4_LINES;
+    s_command.AlternateBytesSize = QSPI_ALTERNATE_BYTES_8_BITS;
+    s_command.AlternateBytes     = 0x000000A0;
+    s_command.DummyCycles        = 6;
+    s_command.DdrMode            = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle   = QSPI_DDR_HHC_ANALOG_DELAY;
+    //s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+    s_command.SIOOMode = QSPI_SIOO_INST_ONLY_FIRST_CMD;
+    s_command.DataMode = QSPI_DATA_4_LINES;
+
+    /* Configure the memory mapped mode */
+    s_mem_mapped_cfg.TimeOutActivation = QSPI_TIMEOUT_COUNTER_DISABLE;
+    s_mem_mapped_cfg.TimeOutPeriod     = 0;
+
+    if(HAL_QSPI_MemoryMapped(&halqspi_, &s_command, &s_mem_mapped_cfg)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    return QSPIHandle::Result::OK;
+}
+
+
+QSPIHandle::Result QSPIHandle::Impl::AutopollingMemReady(uint32_t timeout)
+{
+    QSPI_CommandTypeDef     s_command;
+    QSPI_AutoPollingTypeDef s_config;
+
+    /* Configure automatic polling mode to wait for memory ready */
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction       = READ_STATUS_REG_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_1_LINE;
+    s_command.DummyCycles       = 0;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+
+    s_config.Match         = 0;
+    s_config.MatchMode     = QSPI_MATCH_MODE_AND;
+    s_config.Interval      = 0x10;
+    s_config.AutomaticStop = QSPI_AUTOMATIC_STOP_ENABLE;
+    s_config.Mask          = IS25LP080D_SR_WIP;
+    //s_config.Mask            = 0;
+    s_config.StatusBytesSize = 1;
+
+    if(HAL_QSPI_AutoPolling(&halqspi_, &s_command, &s_config, timeout)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    return QSPIHandle::Result::OK;
+}
+
+QSPIHandle::Result QSPIHandle::Impl::SetMode(QSPIHandle::Config::Mode mode)
+{
+    if(config_.mode != mode)
+    {
+        config_.mode = mode;
+        if(Init(config_) != Result::OK)
+        {
+            config_.mode = Config::Mode::MEMORY_MAPPED;
+            status_      = Status::E_SWITCHING_MODES;
+            Init(config_);
+            return Result::ERR;
+        }
+    }
+    return Result::OK;
+}
+
+QSPIHandle::Result QSPIHandle::Impl::CheckProgramMemory()
+{
+    if(System::GetProgramMemoryRegion() == System::MemoryRegion::QSPI)
+    {
+        status_ = Status::E_INVALID_MODE;
+        // SetMode(Config::Mode::MEMORY_MAPPED);
+        return Result::ERR;
+    }
+    return Result::OK;
+}
+
+QSPIHandle::Result QSPIHandle::Impl::EnterQuadMode()
+{
+    QSPI_CommandTypeDef s_command;
+
+    /* Initialize the read volatile configuration register command */
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction       = ENTER_QUAD_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_NONE;
+    s_command.DummyCycles       = 0;
+    s_command.NbData            = 1;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+
+    /* Configure the command */
+    if(HAL_QSPI_Command(&halqspi_, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    //    /* Wait for WIP bit in SR */
+    //    if (QSPI_AutoPollingMemReady(&halqspi_, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != QSPIHandle::Result::OK)
+    //    {
+    //        return QSPIHandle::Result::ERR;
+    //    }
+    return QSPIHandle::Result::OK;
+}
+
+
+QSPIHandle::Result QSPIHandle::Impl::ExitQuadMode()
+{
+    QSPI_CommandTypeDef s_command;
+
+    /* Initialize the read volatile configuration register command */
+    s_command.InstructionMode   = QSPI_INSTRUCTION_4_LINES;
+    s_command.Instruction       = EXIT_QUAD_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_NONE;
+    s_command.DummyCycles       = 0;
+    s_command.NbData            = 1;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+
+    /* Configure the command */
+    if(HAL_QSPI_Command(&halqspi_, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    /* Wait for WIP bit in SR */
+    if(AutopollingMemReady(HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != QSPIHandle::Result::OK)
+    {
+        ERR_SIMPLE(Status::E_HAL_ERROR);
+    }
+    return QSPIHandle::Result::OK;
+}
+
+
+uint8_t QSPIHandle::Impl::GetStatusRegister()
+{
+    QSPI_CommandTypeDef s_command;
+    uint8_t             reg;
+    reg                         = 0x00;
+    s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
+    s_command.Instruction       = READ_STATUS_REG_CMD;
+    s_command.AddressMode       = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode          = QSPI_DATA_1_LINE;
+    s_command.DummyCycles       = 0;
+    s_command.NbData            = 1;
+    s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+
+    if(HAL_QSPI_Command(&halqspi_, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        return 0x00;
+    }
+    if(HAL_QSPI_Receive(
+           &halqspi_, (uint8_t*)(&reg), HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+       != HAL_OK)
+    {
+        return 0x00;
+    }
+    return reg;
+}
+
+
+uint32_t QSPIHandle::Impl::GetPin(size_t pin)
+{
+    dsy_gpio_pin* p = pin_config_arr_[pin];
+    return dsy_hal_map_get_pin(p);
+}
+
+
+GPIO_TypeDef* QSPIHandle::Impl::GetPort(size_t pin)
+{
+    dsy_gpio_pin* p = pin_config_arr_[pin];
+    return dsy_hal_map_get_port(p);
+}
+
+
+QSPI_HandleTypeDef* QSPIHandle::Impl::GetHalHandle()
+{
+    return &halqspi_;
+}
+
+
+// ======================================================================
+// QSPIHandle > QSPIHandle::Impl
+// ======================================================================
+
+QSPIHandle::Result QSPIHandle::Init(const QSPIHandle::Config& config)
+{
+    pimpl_ = &qspi_impl;
+    return pimpl_->Init(config);
+}
+
+const QSPIHandle::Config& QSPIHandle::GetConfig() const
+{
+    return pimpl_->GetConfig();
+}
+
+QSPIHandle::Result QSPIHandle::DeInit()
+{
+    return pimpl_->DeInit();
+}
+
+QSPIHandle::Status QSPIHandle::GetStatus()
+{
+    return pimpl_->GetStatus();
+}
+
+QSPIHandle::Result
+QSPIHandle::WritePage(uint32_t address, uint32_t size, uint8_t* buffer)
+{
+    return pimpl_->WritePage(address, size, buffer);
+}
+
+QSPIHandle::Result
+QSPIHandle::Write(uint32_t address, uint32_t size, uint8_t* buffer)
+{
+    return pimpl_->Write(address, size, buffer);
+}
+
+QSPIHandle::Result QSPIHandle::Erase(uint32_t start_addr, uint32_t end_addr)
+{
+    return pimpl_->Erase(start_addr, end_addr);
+}
+
+QSPIHandle::Result QSPIHandle::EraseSector(uint32_t address)
+{
+    return pimpl_->EraseSector(address);
+}
+
+void* QSPIHandle::GetData(uint32_t offset)
+{
+    return pimpl_->GetData(offset);
+}
+
+// ======================================================================
+// HAL service functions
+// ======================================================================
+
+extern "C" void HAL_QSPI_MspInit(QSPI_HandleTypeDef* qspiHandle)
+{
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    if(qspiHandle->Instance == QUADSPI)
+    {
+        /* QUADSPI clock enable */
+        __HAL_RCC_QSPI_CLK_ENABLE();
+
+        __HAL_RCC_GPIOG_CLK_ENABLE();
+        __HAL_RCC_GPIOF_CLK_ENABLE();
+        __HAL_RCC_GPIOE_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        // Seems the same for all pin outs so far.
+        uint8_t       af_config[qspi_impl.GetNumPins()] = {GPIO_AF10_QUADSPI,
+                                                     GPIO_AF10_QUADSPI,
+                                                     GPIO_AF9_QUADSPI,
+                                                     GPIO_AF9_QUADSPI,
+                                                     GPIO_AF9_QUADSPI,
+                                                     GPIO_AF10_QUADSPI};
+        GPIO_TypeDef* port;
+        for(uint8_t i = 0; i < qspi_impl.GetNumPins(); i++)
+        {
+            //            port                = (GPIO_TypeDef*)gpio_hal_port_map[qspi_handle.dsy_hqspi->pin_config[i].port];
+            //            GPIO_InitStruct.Pin = gpio_hal_pin_map[qspi_handle.dsy_hqspi->pin_config[i].pin];
+            port                      = qspi_impl.GetPort(i);
+            GPIO_InitStruct.Pin       = qspi_impl.GetPin(i);
+            GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
+            GPIO_InitStruct.Pull      = GPIO_NOPULL;
+            GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
+            GPIO_InitStruct.Alternate = af_config[i];
+            HAL_GPIO_Init(port, &GPIO_InitStruct);
+        }
+        /* QUADSPI interrupt Init */
+        HAL_NVIC_SetPriority(QUADSPI_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(QUADSPI_IRQn);
+    }
+}
+
+extern "C" void HAL_QSPI_MspDeInit(QSPI_HandleTypeDef* qspiHandle)
+{
+    if(qspiHandle->Instance == QUADSPI)
+    {
+        /* Peripheral clock disable */
+        __HAL_RCC_QSPI_CLK_DISABLE();
+        GPIO_TypeDef* port;
+        uint16_t      pin;
+        for(uint8_t i = 0; i < qspi_impl.GetNumPins(); i++)
+        {
+            //            port = (GPIO_TypeDef *)
+            //                gpio_hal_port_map[qspi_handle.dsy_hqspi->pin_config[i].port];
+            //            pin = gpio_hal_pin_map[qspi_handle.dsy_hqspi->pin_config[i].pin];
+            port = qspi_impl.GetPort(i);
+            pin  = qspi_impl.GetPin(i);
+            HAL_GPIO_DeInit(port, pin);
+        }
+        /* QUADSPI interrupt Deinit */
+        HAL_NVIC_DisableIRQ(QUADSPI_IRQn);
+        /* USER CODE BEGIN QUADSPI_MspDeInit 1 */
+
+        /* USER CODE END QUADSPI_MspDeInit 1 */
+    }
+}
+
+extern "C" void QUADSPI_IRQHandler(void)
+{
+    HAL_QSPI_IRQHandler(qspi_impl.GetHalHandle());
+}
+
+} // namespace daisy
+
+/* HAL Overwrite Implementation */
+
+/**QUADSPI GPIO Configuration    
+    On Daisy Rev3:
+    PG6     ------> QUADSPI_BK1_NCS
+    PF8     ------> QUADSPI_BK1_IO0
+    PF9     ------> QUADSPI_BK1_IO1
+    PF7     ------> QUADSPI_BK1_IO2
+    PF6     ------> QUADSPI_BK1_IO3
+    PB2     ------> QUADSPI_CLK 
+    On Daisy Seed:
+    PG6     ------> QUADSPI_BK1_NCS
+    PF8     ------> QUADSPI_BK1_IO0
+    PF9     ------> QUADSPI_BK1_IO1
+    PF7     ------> QUADSPI_BK1_IO2
+    PF6     ------> QUADSPI_BK1_IO3
+    PF10    ------> QUADSPI_CLK 
+    On Audio BB:
+    PG6     ------> QUADSPI_BK1_NCS
+    PF8     ------> QUADSPI_BK1_IO0
+    PF9     ------> QUADSPI_BK1_IO1
+    PE2     ------> QUADSPI_BK1_IO2
+    PF6     ------> QUADSPI_BK1_IO3
+    PF10    ------> QUADSPI_CLK 
+    */
+//enum
+//{
+//    DSY_QSPI_AF_PINS_NCS,
+//    DSY_QSPI_AF_PINS_IO0,
+//    DSY_QSPI_AF_PINS_IO1,
+//    DSY_QSPI_AF_PINS_IO2,
+//    DSY_QSPI_AF_PINS_IO3,
+//    DSY_QSPI_AF_PINS_CLK,
+//    DSY_QSPI_AF_PINS_LAST
+//};
+//static GPIO_TypeDef *gpio_config_ports[DSY_SYS_BOARD_LAST][DSY_QSPI_AF_PINS_LAST] = {
+//    // NCS, IO0,   IO1,   IO2,   IO3,   CLK
+//    {GPIOG, GPIOF, GPIOF, GPIOF, GPIOF, GPIOB}, // DAISY
+//    {GPIOG, GPIOF, GPIOF, GPIOF, GPIOF, GPIOF}, // DAISY SEED
+//    {GPIOG, GPIOF, GPIOF, GPIOE, GPIOF, GPIOF}, // AUDIO BB
+//};
+//static uint16_t gpio_config_pins[DSY_SYS_BOARD_LAST][DSY_QSPI_AF_PINS_LAST] = {
+//    // NCS,         IO0,         IO1,         IO2,         IO3,         CLK
+//    {GPIO_PIN_6, GPIO_PIN_8, GPIO_PIN_9, GPIO_PIN_7, GPIO_PIN_6, GPIO_PIN_2}, // DAISY
+//    {GPIO_PIN_6, GPIO_PIN_8, GPIO_PIN_9, GPIO_PIN_7, GPIO_PIN_6, GPIO_PIN_10}, // DAISY SEED
+//    {GPIO_PIN_6, GPIO_PIN_8, GPIO_PIN_9, GPIO_PIN_2, GPIO_PIN_6, GPIO_PIN_10}, // AUDIO BB
+//};
+//
+//static uint8_t gpio_config_af[DSY_SYS_BOARD_LAST][DSY_QSPI_AF_PINS_LAST] = {
+//    // NCS,                IO0,                IO1,                IO2,                IO3,           CLK
+//    {GPIO_AF10_QUADSPI, GPIO_AF10_QUADSPI, GPIO_AF10_QUADSPI, GPIO_AF9_QUADSPI, GPIO_AF9_QUADSPI, GPIO_AF9_QUADSPI}, // DAISY
+//    {GPIO_AF10_QUADSPI, GPIO_AF10_QUADSPI, GPIO_AF10_QUADSPI, GPIO_AF9_QUADSPI, GPIO_AF9_QUADSPI, GPIO_AF9_QUADSPI}, // DAISY SEED
+//    {GPIO_AF10_QUADSPI, GPIO_AF10_QUADSPI, GPIO_AF10_QUADSPI, GPIO_AF9_QUADSPI, GPIO_AF9_QUADSPI, GPIO_AF9_QUADSPI}, // AUDIO BB
+//};
+//

--- a/src/utility/qspi.h
+++ b/src/utility/qspi.h
@@ -1,0 +1,180 @@
+#pragma once
+
+#ifndef DSY_QSPI
+#define DSY_QSPI /**< Macro */
+
+#include <cstdint>
+#include "daisy_core.h" // Added for dsy_gpio_pin typedef
+
+#define DSY_QSPI_TEXT       \
+    __attribute__((section( \
+        ".qspiflash_text"))) /**< used for reading memory in memory_mapped mode. */
+#define DSY_QSPI_DATA       \
+    __attribute__((section( \
+        ".qspiflash_data"))) /**< used for reading memory in memory_mapped mode. */
+#define DSY_QSPI_BSS        \
+    __attribute__((section( \
+        ".qspiflash_bss"))) /**< used for reading memory in memory_mapped mode. */
+
+namespace daisy
+{
+/** @addtogroup serial
+@{
+*/
+
+/** 
+ Driver for QSPI peripheral to interface with external flash memory. \n 
+    Currently supported QSPI Devices: \n 
+    * IS25LP080D
+*/
+class QSPIHandle
+{
+  public:
+    enum Result
+    {
+        OK = 0,
+        ERR
+    };
+
+    /** Indicates the current status of the module. 
+         *  Warnings are indicated by a leading W.
+         *  Errors are indicated by a leading E and cause an immediate exit.
+         * 
+         *  \param GOOD - No errors have been reported.
+         *  \param E_HAL_ERROR - HAL code did not return HAL_OK.
+         *  \param E_SWITCHING_MODES - An error was encountered while switching QSPI peripheral mode.
+         *  \param E_INVALID_MODE - QSPI should not be written to while the program is executing from it.
+         */
+    enum Status
+    {
+        GOOD = 0,
+        E_HAL_ERROR,
+        E_SWITCHING_MODES,
+        E_INVALID_MODE,
+    };
+
+    /** Configuration structure for interfacing with QSPI Driver */
+    struct Config
+    {
+        /** Flash Devices supported. (Both of these are more-or-less the same, just different sizes). */
+        enum Device
+        {
+            IS25LP080D,  /**< & */
+            IS25LP064A,  /**< & */
+            DEVICE_LAST, /**< & */
+        };
+
+        /** 
+        Modes of operation.
+        Memory Mapped mode: QSPI configured so that the QSPI can be
+        read from starting address 0x90000000. Writing is not
+        possible in this mode. \n 
+        Indirect Polling mode: Device driver enabled. 
+        */
+        enum Mode
+        {
+            MEMORY_MAPPED,    /**< & */
+            INDIRECT_POLLING, /**< & */
+            MODE_LAST,
+        };
+
+        //SCK,  CE# (active low)
+        struct
+        {
+            dsy_gpio_pin io0; /**< & */
+            dsy_gpio_pin io1; /**< & */
+            dsy_gpio_pin io2; /**< & */
+            dsy_gpio_pin io3; /**< & */
+            dsy_gpio_pin clk; /**< & */
+            dsy_gpio_pin ncs; /**< & */
+        } pin_config;
+
+        Device device;
+        Mode   mode;
+    };
+
+    /** 
+        Initializes QSPI peripheral, and Resets, and prepares memory for access.
+        \param config should be populated with the mode, device and pin_config before calling this function.
+        \return Result::OK or Result::ERR
+        */
+    Result Init(const Config& config);
+
+    /** Returns the current config. */
+    const Config& GetConfig() const;
+
+    // Couldn't this just be called before anything else in init? That
+    // would make manually calling it unnecessary.
+    /** 
+        Deinitializes the peripheral
+        This should be called before reinitializing QSPI in a different mode.
+        \return Result::OK or Result::ERR
+        */
+    Result DeInit();
+
+    /** 
+        Writes a single page to to the specified address on the QSPI chip.
+        For IS25LP*, page size is 256 bytes.
+        \param address Address to write to
+        \param size Buffer size
+        \param buffer Buffer to write
+        \return Result::OK or Result::ERR
+        */
+    Result WritePage(uint32_t address, uint32_t size, uint8_t* buffer);
+
+    /** 
+        Writes data in buffer to to the QSPI. Starting at address to address+size 
+        \param address Address to write to
+        \param size Buffer size
+        \param buffer Buffer to write
+        \return Result::OK or Result::ERR
+        */
+    Result Write(uint32_t address, uint32_t size, uint8_t* buffer);
+
+    /** 
+        Erases the area specified on the chip.
+        Erasures will happen by 4K, 32K or 64K increments.
+        Smallest erase possible is 4kB at a time. (on IS25LP*)
+        \param start_addr Address to begin erasing from
+        \param end_addr  Address to stop erasing at
+        \return Result::OK or Result::ERR
+        */
+    Result Erase(uint32_t start_addr, uint32_t end_addr);
+
+    /**  
+         Erases a single sector of the chip.  
+        TODO: Document the size of this function. 
+        \param address Address of sector to erase
+        \return Result::OK or Result::ERR
+        */
+    Result EraseSector(uint32_t address);
+
+    /** Returns the current class status. Useful for debugging.
+     *  \returns Status
+     */
+    Status GetStatus();
+
+    /** Returns a pointer to the actual memory used 
+     *  The memory at this address is read-only
+     *  to write to it use the Write function.
+     * 
+     *  \param offset returns the pointer starting this 
+     *                many bytes into the memory
+    */
+    void* GetData(uint32_t offset = 0);
+
+    QSPIHandle() : pimpl_(nullptr) {}
+    QSPIHandle(const QSPIHandle& other) = default;
+    QSPIHandle& operator=(const QSPIHandle& other) = default;
+
+    class Impl; /**< & */
+
+  private:
+    Impl* pimpl_;
+};
+
+/** @} */
+
+} // namespace daisy
+
+#endif // ifndef DSY_QSPI

--- a/src/utility/system.cpp
+++ b/src/utility/system.cpp
@@ -315,6 +315,11 @@ uint32_t System::GetPClk1Freq()
     return HAL_RCC_GetPCLK1Freq();
 }
 
+uint32_t System::GetTickFreq()
+{
+    return HAL_RCC_GetPCLK1Freq() * 2;
+}
+
 uint32_t System::GetPClk2Freq()
 {
     return HAL_RCC_GetPCLK2Freq();

--- a/src/utility/system.cpp
+++ b/src/utility/system.cpp
@@ -31,6 +31,17 @@ extern "C"
 #define STK_CTRL (STK + 0x00)
 #define RCC_CR RCC
 
+#define SDRAM_BASE 0xC0000000
+
+#define INTERNAL_FLASH_SIZE 0x20000
+#define ITCMRAM_SIZE 0x10000
+#define DTCMRAM_SIZE 0x20000
+#define SRAM_D1_SIZE 0x80000
+#define SRAM_D2_SIZE 0x48000
+#define SRAM_D3_SIZE 0x10000
+#define SDRAM_SIZE 0x4000000
+#define QSPI_SIZE 0x800000
+
 typedef struct
 {
     vu32 ISER[2];
@@ -307,6 +318,34 @@ uint32_t System::GetPClk1Freq()
 uint32_t System::GetPClk2Freq()
 {
     return HAL_RCC_GetPCLK2Freq();
+}
+
+System::MemoryRegion System::GetProgramMemoryRegion()
+{
+    return GetMemoryRegion(SCB->VTOR);
+}
+
+System::MemoryRegion System::GetMemoryRegion(uint32_t addr)
+{
+    if(addr >= D1_AXIFLASH_BASE
+       && addr < D1_AXIFLASH_BASE + INTERNAL_FLASH_SIZE)
+        return MemoryRegion::INTERNAL_FLASH;
+    if(addr >= D1_ITCMRAM_BASE && addr < D1_ITCMRAM_BASE + ITCMRAM_SIZE)
+        return MemoryRegion::ITCMRAM;
+    if(addr >= D1_DTCMRAM_BASE && addr < D1_DTCMRAM_BASE + DTCMRAM_SIZE)
+        return MemoryRegion::DTCMRAM;
+    if(addr >= D1_AXISRAM_BASE && addr < D1_AXISRAM_BASE + SRAM_D1_SIZE)
+        return MemoryRegion::SRAM_D1;
+    if(addr >= D2_AXISRAM_BASE && addr < D2_AXISRAM_BASE + SRAM_D2_SIZE)
+        return MemoryRegion::SRAM_D2;
+    if(addr >= D3_SRAM_BASE && addr < D3_SRAM_BASE + SRAM_D3_SIZE)
+        return MemoryRegion::SRAM_D3;
+    if(addr >= SDRAM_BASE && addr < SDRAM_BASE + SDRAM_SIZE)
+        return MemoryRegion::SDRAM;
+    if(addr >= QSPI_BASE && addr < QSPI_BASE + QSPI_SIZE)
+        return MemoryRegion::QSPI;
+
+    return MemoryRegion::INVALID_ADDRESS;
 }
 
 

--- a/src/utility/system.h
+++ b/src/utility/system.h
@@ -53,6 +53,22 @@ class System
         bool       use_icache;
     };
 
+    /** Describes the different regions of memory available to the Daisy
+     * 
+     */
+    enum MemoryRegion
+    {
+        INTERNAL_FLASH = 0,
+        ITCMRAM,
+        DTCMRAM,
+        SRAM_D1,
+        SRAM_D2,
+        SRAM_D3,
+        SDRAM,
+        QSPI,
+        INVALID_ADDRESS,
+    };
+
     System() {}
     ~System() {}
 
@@ -131,6 +147,17 @@ class System
      ** Returns a const reference to the Systems Configuration struct
      */
     const Config& GetConfig() const { return cfg_; }
+
+    /** Returns an enum representing the current (primary) memory space used 
+     *  for executing the program.
+     */
+    static MemoryRegion GetProgramMemoryRegion();
+
+    /** Returns an enum representing the the memory region 
+     *  that the given address belongs to.
+     *  \param address The address to be checked
+     */
+    static MemoryRegion GetMemoryRegion(uint32_t address);
 
   private:
     void   ConfigureClocks();

--- a/src/utility/system.h
+++ b/src/utility/system.h
@@ -116,6 +116,9 @@ class System
      ** \param delay_ticks Time to ddelay in microseconds */
     static void DelayTicks(uint32_t delay_ticks);
 
+    /** Returns the tick rate in Hz with which GetTick() is incremented. */
+    static uint32_t GetTickFreq();
+
     /** Returns the Frequency of the system clock in Hz 
      ** This is the primary system clock that is used to generate
      ** AXI Peripheral, APB, and AHB clocks. */


### PR DESCRIPTION
Implementation of `daisy::PersistentStorage` and `QSPIHandle`, a single channel `ReverbSc::Process`, `CpuLoadMeter` and related functions from the latest master branch of libDaisy. So far so good while testing my Terrarium/Seed build. Quick example of use:

## Initializing QSPI
```
// QSPI pin configuration for the Daisy Seed

#define PIN_QSPI_CLK dsy_pin(DSY_GPIOF, 10)
#define PIN_QSPI_IO0 dsy_pin(DSY_GPIOF, 8)
#define PIN_QSPI_IO1 dsy_pin(DSY_GPIOF, 9)
#define PIN_QSPI_IO2 dsy_pin(DSY_GPIOF, 7)
#define PIN_QSPI_IO3 dsy_pin(DSY_GPIOF, 6)
#define PIN_QSPI_NCS dsy_pin(DSY_GPIOG, 6)

// Init QSPI
QSPIHandle::Config qspiConfig;

qspiConfig.device = QSPIHandle::Config::IS25LP064A;
qspiConfig.mode = QSPIHandle::Config::MEMORY_MAPPED;

qspiConfig.pin_config.clk = PIN_QSPI_CLK;
qspiConfig.pin_config.io0 = PIN_QSPI_IO0;
qspiConfig.pin_config.io1 = PIN_QSPI_IO1;
qspiConfig.pin_config.io2 = PIN_QSPI_IO2;
qspiConfig.pin_config.io3 = PIN_QSPI_IO3;
qspiConfig.pin_config.ncs = PIN_QSPI_NCS;

QSPIHandle qspi;
qspi.Init(qspiConfig);
```

## daisy::PersistentStorage usage
```
struct StorageData {
  int value;

  bool operator==(StorageData &rhs) {
    return this->value== rhs.value;
  }

  bool operator!=(StorageData &rhs) {
    return !this->operator==(rhs);
  }
};

PersistentStorage<StorageData> storage(qspi);
storage.Init({});

// Save current data from QSPI external flash as the default content (we're backing it up)
storage.GetDefaultSettings() = storage.GetSettings();

// Change value in internal ram buffer
storage.GetSettings().a = 1;

// Write the change to QSPI external flash
storage.Save();

// Restore previous value from QSPI external flash
storage.RestoreDefaults();

// Write the original data to QSPI external flash
storage.Save();
```