### PR TITLE
Edit the CV input number in the comments

### DIFF
--- a/examples/Patch SM/CV_Input/CV_Input.ino
+++ b/examples/Patch SM/CV_Input/CV_Input.ino
@@ -29,7 +29,7 @@ void loop()
     /** Update the control ins */
     patch.ProcessAllControls();
 
-    /** Read from CV_1 */
+    /** Read from CV_5 */
     int value = analogRead(PIN_PATCH_SM_CV_5);
 
     /** Convert AnalogRead range to volts */


### PR DESCRIPTION
This is a very minor change in the comments. 

It made me confused initially since there are already multiple ways that pins are addressed in the patch sm schema (e.g. CV_1 vs C5 vs SIG_KNOB1) and I was getting the hang of how the naming works. (in this case, I thought maybe PIN_PATCH_SM_CV_5 is another way of addressing CV_1 or something) 