### PR TITLE
Update hal_conf_extra.h to prevent "redefinition of symbol" warning

### DIFF
--- a/src/hal_conf_extra.h
+++ b/src/hal_conf_extra.h
@@ -1,6 +1,8 @@
 // These things should be added to the variant.h file within STM32Duino
 // DATA_CACHE_ENABLE requires an update to the linker script (detailed below).
+#ifndef HAL_SDRAM_MODULE_ENABLED
 #define HAL_SDRAM_MODULE_ENABLED
+#endif
 #define HAL_DMA_MODULE_ENABLED
 #define HAL_MDMA_MODULE_ENABLED
 #define HAL_QSPI_MODULE_ENABLED


### PR DESCRIPTION
When using DaisyDuino w/ PlatformIO, the [guidance on the forum](https://forum.electro-smith.com/t/daisy-seed-arduino-development-in-vscode/3639/2) instructs us to add the build flag `-D HAL_SDRAM_MODULE_ENABLED`. Without this, the program will not link due to an `undefined reference to 'HAL_SDRAM_Init'` error.

However, by manually defining the symbol, when we compile we see many "warning symbol redefined" errors. This `ifndef` guard quiets those warnings.

It would probably be better to resolve the issue that requires us to manually define `HAL_SDRAM_MODULE_ENABLED` - what is `HAL_SDRAM_Init` and why is it missing? Unfortunately, this is deeper into the daisy source code that I'm comfortable going.