### PR TITLE
Update README.md with links to daisy.audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Getting Started
 
-Follow the instructions in our [Getting Started Wiki page.](https://github.com/electro-smith/DaisyWiki/wiki/1a.-Getting-Started-(Arduino-Edition)) 
+Follow the instructions in our [Getting Started page.](https://daisy.audio/tutorials/arduino-dev-env/) 
 
 ## Support
 
@@ -20,7 +20,7 @@ Here are some ways to get support and connect with other users and developers:
 
 - Make a [GitHub Issue](https://github.com/electro-smith/DaisyDuino/issues) 
 
-- Join the [Daisy Slack Workspace](https://join.slack.com/t/es-daisy/shared_invite/zt-f9cfm1g4-DgdCok1h1Rj4fpX90~IOww)
+- Join the [Daisy Discor](https://discord.gg/qPPfHczSZV)
 
 ## Built With
 
@@ -31,10 +31,6 @@ Here are some ways to get support and connect with other users and developers:
 ### Additional Dependencies
 
 MIDI examples require the [FortySevenEffects MIDI Library](https://github.com/FortySevenEffects/arduino_midi_library). This library can be installed within the Arduino Library Manager.
-
-## Contributing
-
-Please read our [Contribution Guidelines](https://github.com/electro-smith/DaisyWiki/wiki/6.-Contribution-Guidelines) for details on how to get involved!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here are some ways to get support and connect with other users and developers:
 
 - Make a [GitHub Issue](https://github.com/electro-smith/DaisyDuino/issues) 
 
-- Join the [Daisy Discor](https://discord.gg/qPPfHczSZV)
+- Join the [Daisy Discord](https://discord.gg/qPPfHczSZV)
 
 ## Built With
 


### PR DESCRIPTION
Updated README.md for the Support Site migration (e.g., removing links and any mentions of Daisy wiki).